### PR TITLE
feat: add meal refresh with embeddings and nutrition

### DIFF
--- a/backend/models/food_embedding.py
+++ b/backend/models/food_embedding.py
@@ -1,0 +1,34 @@
+import numpy as np
+from typing import List, Dict
+from config import get_db_connection
+
+
+def get_embeddings(food_ids: List[int]) -> Dict[int, np.ndarray]:
+    """Return a mapping of food_id to embedding vector for given IDs."""
+    if not food_ids:
+        return {}
+    # Remove duplicates to reduce query size
+    unique_ids = list(dict.fromkeys([fid for fid in food_ids if fid is not None]))
+    if not unique_ids:
+        return {}
+
+    conn = get_db_connection()
+    cursor = conn.cursor(dictionary=True)
+    format_strings = ','.join(['%s'] * len(unique_ids))
+    cursor.execute(
+        f"SELECT Food_id, Food_Embedding FROM Food WHERE Food_id IN ({format_strings})",
+        tuple(unique_ids)
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+
+    embeddings: Dict[int, np.ndarray] = {}
+    for row in rows:
+        emb_str = row.get('Food_Embedding') or ''
+        try:
+            vec = np.fromstring(emb_str, sep=',')
+            embeddings[row['Food_id']] = vec
+        except Exception:
+            continue
+    return embeddings

--- a/backend/routes/meal.py
+++ b/backend/routes/meal.py
@@ -6,6 +6,7 @@ from models.meal import Meal
 from services.meal_generate_daily import generate_daily_meal
 from services.meal_generate_weekly import generate_weekly_meal
 from services.meal_generate_monthly import generate_monthly_meal as generate_monthly_meal_plan
+from services.meal_refresh import refresh_daily_meal
 from utils.auth import token_required
 from flask_cors import cross_origin
 
@@ -176,7 +177,33 @@ def regenerate_meal(current_user, date_str):
             'message': f'식단 다시 생성 중 오류가 발생했습니다: {str(e)}'
         }), 500
 
-# 6️⃣ 월별 식단 조회
+# 6️⃣ 특정 날짜의 식단 새로고침
+@meal_bp.route('/api/meals/refresh/<string:date_str>', methods=['POST'])
+@token_required
+def refresh_meal(current_user, date_str):
+    try:
+        user_id = current_user['User_id']
+        date = datetime.datetime.strptime(date_str, '%Y-%m-%d').date()
+        data = request.get_json() or {}
+        target_nutrition = data.get('target_nutrition', {
+            'calories': 600,
+            'carbohydrate': 75,
+            'protein': 20,
+            'fat': 20,
+            'sodium': 700,
+        })
+        result = refresh_daily_meal(user_id, date, target_nutrition)
+        if result:
+            meal = Meal.get_by_user_and_date(user_id, date)
+            return jsonify({'success': True, 'meal': meal, 'nutrition': result.get('nutrition')})
+        else:
+            return jsonify({'success': False, 'message': '식단 새로고침에 실패했습니다.'}), 500
+    except Exception as e:
+        print(f"❌ 식단 새로고침 오류: {e}")
+        traceback.print_exc()
+        return jsonify({'success': False, 'message': str(e)}), 500
+
+# 7️⃣ 월별 식단 조회
 @meal_bp.route('/api/meals/monthly', methods=['GET'])
 @token_required
 def get_monthly_meals(current_user):

--- a/backend/services/meal_refresh.py
+++ b/backend/services/meal_refresh.py
@@ -1,0 +1,107 @@
+import datetime
+import random
+import numpy as np
+from typing import Dict, List
+from services.meal_filter import filter_foods_by_allergy
+from services.meal_nutrition import save_meal_total_nutrition, get_nutrition_by_food_id
+from models.meal import Meal
+from models.food_embedding import get_embeddings
+
+
+def cosine_sim(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size == 0 or b.size == 0:
+        return 0.0
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+def refresh_daily_meal(user_id: int, date: datetime.date, target_nutrition: Dict[str, float], prev_food_ids: List[int] = None):
+    """Generate a refreshed meal considering embeddings and nutrition."""
+    if date is None:
+        date = datetime.date.today()
+
+    # Load candidate foods after allergy filtering
+    foods = filter_foods_by_allergy(user_id)
+
+    # Categorize foods by role
+    rice_list = [f for f in foods if f['Food_role'] == '밥']
+    soup_list = [f for f in foods if f['Food_role'] == '국&찌개']
+    side_dishes_list = [f for f in foods if f['Food_role'] == '반찬']
+    main_dish_list = [f for f in foods if f['Food_role'] == '일품']
+    dessert_list = [f for f in foods if f['Food_role'] == '후식']
+
+    # Previous meal food IDs
+    if prev_food_ids is None:
+        prev_meal = Meal.get_by_user_and_date(user_id, date)
+        prev_food_ids = [
+            prev_meal.get('Rice_id'), prev_meal.get('Soup_id'),
+            prev_meal.get('SideDish1_id'), prev_meal.get('SideDish2_id'),
+            prev_meal.get('MainDish_id'), prev_meal.get('Dessert_id')
+        ] if prev_meal else []
+
+    prev_embeds = list(get_embeddings(prev_food_ids).values())
+
+    # Preload embeddings for all candidate foods
+    candidate_ids = [f['Food_id'] for f in foods]
+    candidate_embeddings = get_embeddings(candidate_ids)
+
+    def random_combo():
+        rice = random.choice(rice_list) if rice_list else None
+        soup = random.choice(soup_list) if soup_list else None
+        side_dishes = random.sample(side_dishes_list, min(2, len(side_dishes_list))) if side_dishes_list else []
+        main_dish = random.choice(main_dish_list) if main_dish_list else None
+        dessert = random.choice(dessert_list) if dessert_list else None
+        return [rice, soup] + side_dishes + [main_dish, dessert]
+
+    def score_combo(combo):
+        food_ids = [f['Food_id'] for f in combo if f]
+        # Similarity score
+        sim = 0.0
+        for fid in food_ids:
+            emb = candidate_embeddings.get(fid)
+            if emb is not None and prev_embeds:
+                sim += max(cosine_sim(emb, p) for p in prev_embeds)
+        # Nutrition difference
+        totals = {'calories':0,'carbohydrate':0,'protein':0,'fat':0,'sodium':0}
+        for fid in food_ids:
+            n = get_nutrition_by_food_id(fid)
+            for k in totals:
+                totals[k] += n.get(k,0)
+        diff = sum(abs(totals[k]-target_nutrition.get(k,0)) for k in totals)
+        return sim + diff, totals, food_ids
+
+    best = None
+    best_totals = None
+    best_ids = None
+    best_score = float('inf')
+    for _ in range(50):
+        combo = random_combo()
+        score, totals, ids = score_combo(combo)
+        if score < best_score:
+            best_score = score
+            best = combo
+            best_totals = totals
+            best_ids = ids
+
+    if not best:
+        return None
+
+    # Save meal
+    rice = best[0]; soup = best[1]; side_dish1 = best[2] if len(best) > 2 else None
+    side_dish2 = best[3] if len(best) > 3 else None
+    main_dish = best[4] if len(best) > 4 else None
+    dessert = best[5] if len(best) > 5 else None
+
+    meal = Meal(
+        User_id=user_id,
+        Date=date,
+        Rice_id=rice['Food_id'] if rice else None,
+        Soup_id=soup['Food_id'] if soup else None,
+        SideDish1_id=side_dish1['Food_id'] if side_dish1 else None,
+        SideDish2_id=side_dish2['Food_id'] if side_dish2 else None,
+        MainDish_id=main_dish['Food_id'] if main_dish else None,
+        Dessert_id=dessert['Food_id'] if dessert else None,
+    )
+    meal_id = meal.save()
+
+    nutrition_summary = save_meal_total_nutrition(meal_id, best_ids)
+    return {'meal_id': meal_id, 'nutrition': nutrition_summary}

--- a/src/components/meal/DietPlanView.jsx
+++ b/src/components/meal/DietPlanView.jsx
@@ -8,6 +8,7 @@ const DietPlanView = ({
   weekdays, days, prevMonth, nextMonth, formatMonth, expandedDate, isSameDate, isCurrentMonth, isWeekend,
   handleDateClick, hasMealData, meals, formatDateString, selectedMenuItem, handleMenuItemClick, handleFoodClick,
   formatDate, selectedDate, formatSelectedDate, loading, selectedMeal, handleRegenerateMeal, showFoodDetail, selectedFoodId, handleCloseFoodDetail,
+  handleRefreshMeal,
   showGenerateOptions, handleShowGenerateOptions, handleGenerateByType
 }) => (
   <div className="diet-plan-container">
@@ -132,6 +133,7 @@ const DietPlanView = ({
           }</span>
         )}
       </div>
+      <button className="diet-create-btn" onClick={() => handleRefreshMeal(selectedDate)}>새로고침</button>
       {loading ? (
         <div className="loading-message">식단 정보를 불러오는 중...</div>
       ) : selectedMeal ? (

--- a/src/components/meal/useDietPlan.js
+++ b/src/components/meal/useDietPlan.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getMonthlyMeals, generateMonthlyMeals, regenerateMeal } from '../../services/mealService';
+import { getMonthlyMeals, generateMonthlyMeals, regenerateMeal, refreshMeal } from '../../services/mealService';
 import axios from 'axios';
 
 export default function useDietPlan() {
@@ -77,6 +77,27 @@ export default function useDietPlan() {
       }
     } catch (err) {
       setError('서버에 연결할 수 없거나 식단 재생성에 실패했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRefreshMeal = async (date) => {
+    try {
+      setLoading(true);
+      const dateString = formatDateString(date);
+      const response = await refreshMeal(dateString);
+      if (response.success) {
+        loadMeals();
+        if (response.meal) {
+          setSelectedMeal(response.meal);
+        }
+      } else {
+        setError(response.message || '식단 새로고침에 실패했습니다.');
+      }
+    } catch (err) {
+      setError('서버에 연결할 수 없거나 식단 새로고침에 실패했습니다.');
       console.error(err);
     } finally {
       setLoading(false);
@@ -283,7 +304,7 @@ export default function useDietPlan() {
     meals, setMeals, selectedMeal, setSelectedMeal, loading, setLoading, error, setError,
     generating, setGenerating, expandedDate, setExpandedDate, selectedMenuItem, setSelectedMenuItem,
     selectedFoodId, setSelectedFoodId, showFoodDetail, setShowFoodDetail,
-    loadMeals, handleGenerateMeals, handleRegenerateMeal, getDaysInMonth, handleDateClick,
+    loadMeals, handleGenerateMeals, handleRegenerateMeal, handleRefreshMeal, getDaysInMonth, handleDateClick,
     handleMenuItemClick, handleFoodClick, handleCloseFoodDetail, prevMonth, nextMonth, goToToday,
     formatDate, formatDateString, formatMonth, formatSelectedDate, isSameDate, isCurrentMonth, isWeekend,
     handleViewTypeChange, hasMealData, weekdays, days,

--- a/src/services/mealService.js
+++ b/src/services/mealService.js
@@ -115,6 +115,25 @@ export const regenerateMeal = async (date) => {
   }
 };
 
+// 임베딩/영양소 기반 새로고침
+export const refreshMeal = async (date) => {
+  try {
+    const authHeader = getAuthHeader();
+    const response = await axios.post(
+      `${API_URL}/meals/refresh/${date}`,
+      {},
+      authHeader
+    );
+    return response.data;
+  } catch (error) {
+    console.error('식단 새로고침 오류:', error);
+    if (error.response) {
+      console.error('서버 응답:', error.response.status, error.response.data);
+    }
+    throw error;
+  }
+};
+
 export const getMealNutritionByDate = async (date, token) => {
   try {
     const response = await fetch(


### PR DESCRIPTION
## Summary
- implement meal refresh service using food embeddings and nutrition scoring
- expose `/api/meals/refresh/<date>` endpoint with target nutrition option
- add frontend refresh button and service to request refreshed meals

## Testing
- `npm test` *(fails: Missing script 'test')*
- `pytest` *(0 tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_6895e310c1d88325babe5e32030db89e