### PR TITLE
Enable refreshing individual menu items

### DIFF
--- a/backend/routes/meal.py
+++ b/backend/routes/meal.py
@@ -6,7 +6,7 @@ from models.meal import Meal
 from services.meal_generate_daily import generate_daily_meal
 from services.meal_generate_weekly import generate_weekly_meal
 from services.meal_generate_monthly import generate_monthly_meal as generate_monthly_meal_plan
-from services.meal_refresh import refresh_daily_meal
+from services.meal_refresh import refresh_daily_meal, refresh_single_menu_item
 from utils.auth import token_required
 from flask_cors import cross_origin
 
@@ -192,7 +192,11 @@ def refresh_meal(current_user, date_str):
             'fat': 20,
             'sodium': 700,
         })
-        result = refresh_daily_meal(user_id, date, target_nutrition)
+        item = data.get('item')
+        if item:
+            result = refresh_single_menu_item(user_id, date, item, target_nutrition)
+        else:
+            result = refresh_daily_meal(user_id, date, target_nutrition)
         if result:
             meal = Meal.get_by_user_and_date(user_id, date)
             return jsonify({'success': True, 'meal': meal, 'nutrition': result.get('nutrition')})

--- a/src/components/meal/DietPlanView.jsx
+++ b/src/components/meal/DietPlanView.jsx
@@ -7,7 +7,7 @@ const DietPlanView = ({
   currentDate, viewType, handleViewTypeChange, generating, error,
   weekdays, days, prevMonth, nextMonth, formatMonth, expandedDate, isSameDate, isCurrentMonth, isWeekend,
   handleDateClick, hasMealData, meals, formatDateString, selectedMenuItem, handleMenuItemClick, handleFoodClick,
-  formatDate, selectedDate, formatSelectedDate, loading, selectedMeal, handleRegenerateMeal, showFoodDetail, selectedFoodId, handleCloseFoodDetail,
+  formatDate, selectedDate, formatSelectedDate, loading, selectedMeal, showFoodDetail, selectedFoodId, handleCloseFoodDetail,
   handleRefreshMeal,
   showGenerateOptions, handleShowGenerateOptions, handleGenerateByType
 }) => (
@@ -133,7 +133,13 @@ const DietPlanView = ({
           }</span>
         )}
       </div>
-      <button className="diet-create-btn" onClick={() => handleRefreshMeal(selectedDate)}>새로고침</button>
+      <button
+        className="diet-create-btn"
+        onClick={() => handleRefreshMeal(selectedDate, selectedMenuItem)}
+        disabled={!selectedMenuItem}
+      >
+        새로고침
+      </button>
       {loading ? (
         <div className="loading-message">식단 정보를 불러오는 중...</div>
       ) : selectedMeal ? (

--- a/src/components/meal/useDietPlan.js
+++ b/src/components/meal/useDietPlan.js
@@ -83,11 +83,15 @@ export default function useDietPlan() {
     }
   };
 
-  const handleRefreshMeal = async (date) => {
+  const handleRefreshMeal = async (date, item) => {
+    if (!item) {
+      setError('새로고칠 메뉴를 선택해주세요.');
+      return;
+    }
     try {
       setLoading(true);
       const dateString = formatDateString(date);
-      const response = await refreshMeal(dateString);
+      const response = await refreshMeal(dateString, item);
       if (response.success) {
         loadMeals();
         if (response.meal) {

--- a/src/services/mealService.js
+++ b/src/services/mealService.js
@@ -116,40 +116,29 @@ export const regenerateMeal = async (date) => {
 };
 
 // 임베딩/영양소 기반 새로고침
-export const refreshMeal = async (date) => {
-  try {
-    const authHeader = getAuthHeader();
-    const response = await axios.post(
-      `${API_URL}/meals/refresh/${date}`,
-      {},
-      authHeader
-    );
-    return response.data;
-  } catch (error) {
-    console.error('식단 새로고침 오류:', error);
-    if (error.response) {
-      console.error('서버 응답:', error.response.status, error.response.data);
-    }
-    throw error;
-  }
+export const refreshMeal = async (date, item = null) => {
+  const authHeader = getAuthHeader();
+  const body = item ? { item } : {};
+  const response = await axios.post(
+    `${API_URL}/meals/refresh/${date}`,
+    body,
+    authHeader
+  );
+  return response.data;
 };
 
 export const getMealNutritionByDate = async (date, token) => {
-  try {
-    const response = await fetch(
-      `${API_URL}/meal-nutrition/${date}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: token ? `Bearer ${token}` : undefined,
-        },
-      }
-    );
-    const data = await response.json();
-    if (!response.ok) throw new Error(data.message || '영양소 정보 조회 실패');
-    return data;
-  } catch (error) {
-    throw error;
-  }
+  const response = await fetch(
+    `${API_URL}/meal-nutrition/${date}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token ? `Bearer ${token}` : undefined,
+      },
+    }
+  );
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.message || '영양소 정보 조회 실패');
+  return data;
 };


### PR DESCRIPTION
## Summary
- support refreshing a single menu item while recalculating meal nutrition
- allow client to request item-level refresh and only enable refresh when a menu is selected

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/services/mealService.js src/components/meal/useDietPlan.js src/components/meal/DietPlanView.jsx`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895edfb85948325b97764398926a839