### PR TITLE
Add per-meal refresh buttons

### DIFF
--- a/src/components/meal/DietPlan.css
+++ b/src/components/meal/DietPlan.css
@@ -568,6 +568,23 @@
   opacity: 1;
 }
 
+/* 개별 식단 새로고침 버튼 */
+.refresh-meal-btn {
+  margin-left: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: #4285f4;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.refresh-meal-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* 음식 상세 정보 모달 */
 .food-detail-modal {
   position: fixed;

--- a/src/components/meal/DietPlanView.jsx
+++ b/src/components/meal/DietPlanView.jsx
@@ -133,13 +133,6 @@ const DietPlanView = ({
           }</span>
         )}
       </div>
-      <button
-        className="diet-create-btn"
-        onClick={() => handleRefreshMeal(selectedDate, selectedMenuItem)}
-        disabled={!selectedMenuItem}
-      >
-        새로고침
-      </button>
       {loading ? (
         <div className="loading-message">식단 정보를 불러오는 중...</div>
       ) : selectedMeal ? (
@@ -148,7 +141,17 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">밥</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.rice_id)} className="food-item-clickable">{selectedMeal.rice_name}</li>
+                <li>
+                  <span onClick={() => handleFoodClick(selectedMeal.rice_id)} className="food-item-clickable">{selectedMeal.rice_name}</span>
+                  <button
+                    className="refresh-meal-btn"
+                    onClick={() => handleRefreshMeal(selectedDate, 'rice')}
+                    disabled={loading}
+                    title="밥 새로고침"
+                  >
+                    ⟳
+                  </button>
+                </li>
               </ul>
             </div>
           )}
@@ -156,7 +159,17 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">국/찌개</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.soup_id)} className="food-item-clickable">{selectedMeal.soup_name}</li>
+                <li>
+                  <span onClick={() => handleFoodClick(selectedMeal.soup_id)} className="food-item-clickable">{selectedMeal.soup_name}</span>
+                  <button
+                    className="refresh-meal-btn"
+                    onClick={() => handleRefreshMeal(selectedDate, 'soup')}
+                    disabled={loading}
+                    title="국/찌개 새로고침"
+                  >
+                    ⟳
+                  </button>
+                </li>
               </ul>
             </div>
           )}
@@ -165,10 +178,30 @@ const DietPlanView = ({
               <h3 className="meal-title">반찬</h3>
               <ul className="meal-items">
                 {selectedMeal.side_dish1_id && (
-                  <li onClick={() => handleFoodClick(selectedMeal.side_dish1_id)} className="food-item-clickable">{selectedMeal.side_dish1_name}</li>
+                  <li>
+                    <span onClick={() => handleFoodClick(selectedMeal.side_dish1_id)} className="food-item-clickable">{selectedMeal.side_dish1_name}</span>
+                    <button
+                      className="refresh-meal-btn"
+                      onClick={() => handleRefreshMeal(selectedDate, 'side_dish1')}
+                      disabled={loading}
+                      title="반찬1 새로고침"
+                    >
+                      ⟳
+                    </button>
+                  </li>
                 )}
                 {selectedMeal.side_dish2_id && (
-                  <li onClick={() => handleFoodClick(selectedMeal.side_dish2_id)} className="food-item-clickable">{selectedMeal.side_dish2_name}</li>
+                  <li>
+                    <span onClick={() => handleFoodClick(selectedMeal.side_dish2_id)} className="food-item-clickable">{selectedMeal.side_dish2_name}</span>
+                    <button
+                      className="refresh-meal-btn"
+                      onClick={() => handleRefreshMeal(selectedDate, 'side_dish2')}
+                      disabled={loading}
+                      title="반찬2 새로고침"
+                    >
+                      ⟳
+                    </button>
+                  </li>
                 )}
               </ul>
             </div>
@@ -177,7 +210,17 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">메인요리</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.main_dish_id)} className="food-item-clickable">{selectedMeal.main_dish_name}</li>
+                <li>
+                  <span onClick={() => handleFoodClick(selectedMeal.main_dish_id)} className="food-item-clickable">{selectedMeal.main_dish_name}</span>
+                  <button
+                    className="refresh-meal-btn"
+                    onClick={() => handleRefreshMeal(selectedDate, 'main_dish')}
+                    disabled={loading}
+                    title="메인요리 새로고침"
+                  >
+                    ⟳
+                  </button>
+                </li>
               </ul>
             </div>
           )}
@@ -185,7 +228,17 @@ const DietPlanView = ({
             <div className="meal-block">
               <h3 className="meal-title">디저트</h3>
               <ul className="meal-items">
-                <li onClick={() => handleFoodClick(selectedMeal.dessert_id)} className="food-item-clickable">{selectedMeal.dessert_name}</li>
+                <li>
+                  <span onClick={() => handleFoodClick(selectedMeal.dessert_id)} className="food-item-clickable">{selectedMeal.dessert_name}</span>
+                  <button
+                    className="refresh-meal-btn"
+                    onClick={() => handleRefreshMeal(selectedDate, 'dessert')}
+                    disabled={loading}
+                    title="디저트 새로고침"
+                  >
+                    ⟳
+                  </button>
+                </li>
               </ul>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add refresh icons for individual meal items
- remove global refresh control
- style refresh icon button
- make per-meal refresh icons visible and accessible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6895f1d477a08325ae3888ed69591aed